### PR TITLE
docs: fix grammar in devcontainer instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want debug in vscode devcontainer, try to open the project with devcontai
 
 - Step1: Press **Ctrl + Shift+ P** in vscode;
 - Step2: Type **Dev Containers: Reopen in Container**;
-- Step3: Click the item which appear in column;
+- Step3: Click the item which **appears** in the column;
 - Step4: Open a terminal, build & run app with command;
 
 <br>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want debug in vscode devcontainer, try to open the project with devcontai
 
 - Step1: Press **Ctrl + Shift+ P** in vscode;
 - Step2: Type **Dev Containers: Reopen in Container**;
-- Step3: Click the item which **appears** in the column;
+- Step3: Click the item which appears in the column;
 - Step4: Open a terminal, build & run app with command;
 
 <br>


### PR DESCRIPTION
## Summary
- fix grammar in devcontainer instructions in README

## Testing
- `grep -n "appears" -n README.md | head`


------
https://chatgpt.com/codex/tasks/task_b_683e17d59d4c8329acfa9ae26a08da7f